### PR TITLE
[#12] Atlas and contribution guidelines

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = gsw
 	url = https://github.com/TrySpaceOrg/tryspace-ext-yamcs.git
 	branch = master
+[submodule "atlas"]
+	path = atlas
+	url = https://github.com/TrySpaceOrg/TrySpaceOrg.github.io.git
+	branch = main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to TrySpace Lab
+
+Thank you for considering contributing to TrySpace Lab!
+We welcome contributions from everyone.
+To ensure a smooth collaboration, please follow these guidelines:
+
+## How to Contribute
+
+1. **Fork the Repository**: Start by forking the repository to your GitHub account.
+2. **Create a Branch**: Create a new branch for your feature or bug fix. Use a descriptive name, such as `feature/add-new-tool` or `bugfix/fix-typo`.
+3. **Make Changes**: Implement your changes in the new branch. Ensure your code follows the project's coding standards.
+4. **Test Your Changes**: Run tests to verify that your changes work as expected and do not break existing functionality.
+5. **Submit a Pull Request**: Open a pull request (PR) to the `dev` branch of this repository. Provide a clear description of your changes and reference any related issues.
+
+## Licensing
+
+By contributing to this repository, you agree that your contributions will be licensed under the [GNU Affero General Public License v3 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.html) or any other license explicitly noted in the repository.
+Please ensure you are comfortable with this licensing before submitting your contributions.
+
+## Questions or Feedback
+
+If you have any questions or need further clarification, feel free to open a [GitHub Discussion](https://github.com/TrySpaceOrg/tryspace-lab/discussions) or contact the maintainers directly.
+
+Thank you for your contributions and support!

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Discussions are a great place to engage with the community and maintainers.
 
 For bug reports or feature requests, please open a [GitHub Issue](https://github.com/TrySpaceOrg/tryspace-lab/issues).
 
+## Documentation
+
+The full documentation for TrySpace Lab is available at [TrySpace Atlas](https://tryspaceorg.github.io/).
+
 ## Contributing
 
 We welcome contributions from everyone. Please review our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # TrySpace Lab
+
 Entrypoint for orchestrating full TrySpace simulation environments.
+
+## Community Support
+
+If you have questions, ideas, or need help, feel free to start a [GitHub Discussion](https://github.com/TrySpaceOrg/tryspace-lab/discussions).
+Discussions are a great place to engage with the community and maintainers.
+
+For bug reports or feature requests, please open a [GitHub Issue](https://github.com/TrySpaceOrg/tryspace-lab/issues).
+
+## Contributing
+
+We welcome contributions from everyone. Please review our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started.
+
+## Licensing
+
+This project is licensed under the [GNU Affero General Public License v3 (AGPLv3)](https://www.gnu.org/licenses/agpl-3.0.html).
+By contributing, you agree that your contributions will also be licensed under the AGPLv3 or any other license explicitly noted in the repository.


### PR DESCRIPTION
Created https://tryspaceorg.github.io/ and added the contribution guidelines to tryspace-lab.

Closes #12
Closes #13 
